### PR TITLE
Property-based tests: ISBN conversion

### DIFF
--- a/isbn.cabal
+++ b/isbn.cabal
@@ -59,6 +59,7 @@ test-suite isbn-test
   main-is:             Spec.hs
   build-depends:       base
                      , hspec >= 2.7 && < 3
+                     , QuickCheck >= 2.14 && < 3
                      , isbn
                      , text
   other-modules:       Data.ISBNSpec

--- a/nixpkgs.json
+++ b/nixpkgs.json
@@ -1,6 +1,6 @@
 {
     "owner": "NixOS",
     "repo": "nixpkgs",
-    "rev": "bc260badaebf67442befe20fb443034d3a91f2b3",
-    "sha256": "1iysc4xyk88ngkfb403xfq5bs3zy29zfs83pn99kchxd45nbpb5q"
+    "rev": "1b688ca59ba78525308e963548eff6f3bebc221e",
+    "sha256": "1zr12pimiq9083almhpr5x2dgk95iif0cqmjvz749mlwgks2qmvh"
 }


### PR DESCRIPTION
- Added quickcheck-based property tests for ISBN-10 to ISBN-13 conversions and vise versa
- Bumped nixpkgs.json to latest 20.09 release