### PR TITLE
Bump haskell/actions from v1 to v1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           ghc: 'latest'
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v1.2.1
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Bump `haskell/actions` from `v1` to `v1.2.1`.